### PR TITLE
Add support for Hashicorp Vault

### DIFF
--- a/.scripts/initVault.sh
+++ b/.scripts/initVault.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+vault server -dev &
+sleep 3
+export VAULT_ADDR='http://127.0.0.1:8200'
+vault secrets enable transit
+vault write transit/keys/identity-cookie type=rsa-2048 exportable=true
+vault write transit/keys/identity-token type=rsa-2048 exportable=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: java
 jdk:
   - openjdk8
 before_install:
+  - "curl https://releases.hashicorp.com/vault/1.1.3/vault_1.1.3_linux_amd64.zip --output vault.zip"
+  - unzip vault.zip
+  - export PATH=$PATH:$(pwd)
   - mkdir .secret
   - bash .scripts/buildDB.sh
   - bash .scripts/initKey.sh
+  - bash .scripts/initVault.sh
 script:
   - mvn clean package spotbugs:check jetty:run &
   # sleep to wait for jetty service to be ready

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,18 @@
             <version>1.46</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180813</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/com/yahoo/identity/services/credential/CredentialImpl.java
+++ b/src/main/java/com/yahoo/identity/services/credential/CredentialImpl.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import javax.annotation.Nonnull;
 
 public class CredentialImpl implements Credential {
+    private static final String KEY_NAME = "identity-cookie";
 
     private final KeyService keyService;
     private Instant issueTime;
@@ -75,8 +76,8 @@ public class CredentialImpl implements Credential {
     public String toString() {
         try {
             Algorithm algorithm =
-                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey("cookie-public.pem", "RSA"),
-                                 (RSAPrivateKey) this.keyService.getPrivateKey("cookie-private.pem", "RSA"));
+                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey(KEY_NAME, "RSA"),
+                                 (RSAPrivateKey) this.keyService.getPrivateKey(KEY_NAME, "RSA"));
 
             String cookie = JWT.create()
                 .withExpiresAt(Date.from(getExpireTime()))

--- a/src/main/java/com/yahoo/identity/services/credential/CredentialServiceImpl.java
+++ b/src/main/java/com/yahoo/identity/services/credential/CredentialServiceImpl.java
@@ -15,6 +15,7 @@ import java.security.interfaces.RSAPublicKey;
 import javax.annotation.Nonnull;
 
 public class CredentialServiceImpl implements CredentialService {
+    private static final String KEY_NAME = "identity-cookie";
 
     private final KeyService keyService;
     private final Credential credential;
@@ -29,8 +30,8 @@ public class CredentialServiceImpl implements CredentialService {
     public Credential fromString(@Nonnull String credStr) {
         try {
             Algorithm algorithm =
-                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey("cookie-public.pem", "RSA"),
-                                 (RSAPrivateKey) this.keyService.getPrivateKey("cookie-private.pem", "RSA"));
+                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey(KEY_NAME, "RSA"),
+                                 (RSAPrivateKey) this.keyService.getPrivateKey(KEY_NAME, "RSA"));
 
             JWTVerifier verifier = JWT.require(algorithm).acceptExpiresAt(0).build();
 

--- a/src/main/java/com/yahoo/identity/services/key/KeyServiceImpl.java
+++ b/src/main/java/com/yahoo/identity/services/key/KeyServiceImpl.java
@@ -12,8 +12,6 @@ import javax.ws.rs.InternalServerErrorException;
 
 public class KeyServiceImpl implements KeyService {
 
-    private final KeyServiceUtils keyServiceUtils = new KeyServiceUtils();
-
     private static String readFileAsString(String fileName) throws Exception {
         return Base64.getEncoder().encodeToString((Files.readAllBytes(Paths.get(fileName))));
     }
@@ -32,9 +30,9 @@ public class KeyServiceImpl implements KeyService {
 
     @Override
     @Nonnull
-    public PublicKey getPublicKey(@Nonnull String publicKeyName, @Nonnull String crpytoScheme) {
+    public PublicKey getPublicKey(@Nonnull String publicKeyName, @Nonnull String cryptoScheme) {
         try {
-            return KeyServiceUtils.readPublicKeyFromFile(".secret/" + publicKeyName, crpytoScheme);
+            return KeyServiceUtils.readPublicKeyFromVault(publicKeyName, cryptoScheme);
         } catch (Exception e) {
             throw new InternalServerErrorException("Unknown error occurs when reading file: " + e.toString());
         }
@@ -42,9 +40,9 @@ public class KeyServiceImpl implements KeyService {
 
     @Override
     @Nonnull
-    public PrivateKey getPrivateKey(@Nonnull String privateKeyName, @Nonnull String crpytoScheme) {
+    public PrivateKey getPrivateKey(@Nonnull String privateKeyName, @Nonnull String cryptoScheme) {
         try {
-            return KeyServiceUtils.readPrivateKeyFromFile(".secret/" + privateKeyName, crpytoScheme);
+            return KeyServiceUtils.readPrivateKeyFromVault(privateKeyName, cryptoScheme);
         } catch (Exception e) {
             throw new InternalServerErrorException("Unknown error occurs when reading file: " + e.toString());
         }

--- a/src/main/java/com/yahoo/identity/services/key/KeyServiceUtils.java
+++ b/src/main/java/com/yahoo/identity/services/key/KeyServiceUtils.java
@@ -2,14 +2,17 @@ package com.yahoo.identity.services.key;
 
 import com.yahoo.identity.IdentityError;
 import com.yahoo.identity.IdentityException;
+import org.apache.commons.io.IOUtils;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -20,18 +23,66 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
 public class KeyServiceUtils {
+    private static final String CMD_READ_PUBLIC_KEY = "vault read -format=json transit/keys/";
+    private static final String CMD_READ_PRIVATE_KEY = "vault read -format=json transit/export/signing-key/";
 
-    private static byte[] parsePEMFile(File pemFile) throws IOException {
-        if (!pemFile.isFile() || !pemFile.exists()) {
+    private static JSONObject getStdoutFromExec(String cmd) {
+        try {
+            Process process = Runtime.getRuntime().exec(cmd);
+            int rc = process.waitFor();
+            if (rc != 0) {
+                throw new IdentityException(IdentityError.INTERNAL_SERVER_ERROR,
+                                            "Exec returned a non-zero code.",
+                                            new Throwable(IOUtils.toString(process.getErrorStream(), "UTF-8")));
+            }
+            return new JSONObject(new JSONTokener(process.getInputStream()));
+
+        } catch (java.io.IOException e) {
             throw new IdentityException(IdentityError.INTERNAL_SERVER_ERROR,
-                                        String.format("The file '%s' doesn't exist.", pemFile.getAbsolutePath()));
+                                        "Exec failed due to I/O error.",
+                                        e);
+        } catch (java.lang.InterruptedException e) {
+            throw new IdentityException(IdentityError.INTERNAL_SERVER_ERROR,
+                                        "The thread was interrupted when waiting for child process to finish execution.",
+                                        e);
         }
-        InputStream inputStream = new FileInputStream(pemFile);
+    }
+
+    private static byte[] PKCS1ToPKCS8(byte[] PKCS1Bytes) {
+        try {
+            Process process = Runtime.getRuntime().exec("openssl pkcs8 -topk8 -nocrypt");
+
+            OutputStream outputStream = process.getOutputStream();
+            outputStream.write(PKCS1Bytes);
+            outputStream.flush();
+            outputStream.close();
+
+            int rc = process.waitFor();
+            if (rc != 0) {
+                throw new IdentityException(IdentityError.INTERNAL_SERVER_ERROR,
+                                            "Exec returned a non-zero code.",
+                                            new Throwable(IOUtils.toString(process.getErrorStream(), "UTF-8")));
+            }
+
+            return IOUtils.toByteArray(process.getInputStream());
+
+        } catch (java.io.IOException e) {
+            throw new IdentityException(IdentityError.INTERNAL_SERVER_ERROR,
+                                        "Exec failed due to I/O error.",
+                                        e);
+        } catch (java.lang.InterruptedException e) {
+            throw new IdentityException(IdentityError.INTERNAL_SERVER_ERROR,
+                                        "The thread was interrupted when waiting for child process to finish execution.",
+                                        e);
+        }
+    }
+
+    private static byte[] parsePEM(byte[] PEMBytes) throws IOException {
+        InputStream inputStream = new ByteArrayInputStream(PEMBytes);
         PemReader reader = new PemReader(new InputStreamReader(inputStream, "UTF-8"));
         PemObject pemObject = reader.readPemObject();
-        byte[] content = pemObject.getContent();
         reader.close();
-        return content;
+        return pemObject.getContent();
     }
 
     private static PublicKey getPublicKey(byte[] keyBytes, String algorithm) {
@@ -70,13 +121,22 @@ public class KeyServiceUtils {
         return privateKey;
     }
 
-    public static PublicKey readPublicKeyFromFile(String filepath, String algorithm) throws IOException {
-        byte[] bytes = KeyServiceUtils.parsePEMFile(new File(filepath));
+    public static PublicKey readPublicKeyFromVault(String keyName, String algorithm) throws IOException {
+        String keyStr = getStdoutFromExec(CMD_READ_PUBLIC_KEY + keyName)
+            .getJSONObject("data")
+            .getJSONObject("keys")
+            .getJSONObject("1")
+            .getString("public_key");
+        byte[] bytes = KeyServiceUtils.parsePEM(keyStr.getBytes("UTF-8"));
         return KeyServiceUtils.getPublicKey(bytes, algorithm);
     }
 
-    public static PrivateKey readPrivateKeyFromFile(String filepath, String algorithm) throws IOException {
-        byte[] bytes = KeyServiceUtils.parsePEMFile(new File(filepath));
+    public static PrivateKey readPrivateKeyFromVault(String keyName, String algorithm) throws IOException {
+        String keyStr = getStdoutFromExec(CMD_READ_PRIVATE_KEY + keyName)
+            .getJSONObject("data")
+            .getJSONObject("keys")
+            .getString("1");
+        byte[] bytes = KeyServiceUtils.parsePEM(PKCS1ToPKCS8(keyStr.getBytes("UTF-8")));
         return KeyServiceUtils.getPrivateKey(bytes, algorithm);
     }
 }

--- a/src/main/java/com/yahoo/identity/services/token/TokenImpl.java
+++ b/src/main/java/com/yahoo/identity/services/token/TokenImpl.java
@@ -11,12 +11,12 @@ import org.apache.commons.lang3.Validate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
 
 public class TokenImpl implements Token {
+    private static final String KEY_NAME = "identity-token";
 
     public static class Builder {
         private Instant issueTime;
@@ -75,8 +75,8 @@ public class TokenImpl implements Token {
     public String toString() {
         try {
             Algorithm algorithm =
-                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey("token-public.pem", "RSA"),
-                                 (RSAPrivateKey) this.keyService.getPrivateKey("token-private.pem", "RSA"));
+                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey(KEY_NAME, "RSA"),
+                                 (RSAPrivateKey) this.keyService.getPrivateKey(KEY_NAME, "RSA"));
             return JWT.create()
                 .withExpiresAt(Date.from(this.expireTime))
                 .withIssuedAt(Date.from(this.issueTime))

--- a/src/main/java/com/yahoo/identity/services/token/TokenServiceImpl.java
+++ b/src/main/java/com/yahoo/identity/services/token/TokenServiceImpl.java
@@ -15,6 +15,7 @@ import java.security.interfaces.RSAPublicKey;
 import javax.annotation.Nonnull;
 
 public class TokenServiceImpl implements TokenService {
+    private static final String KEY_NAME = "identity-token";
 
     private final KeyService keyService;
 
@@ -33,8 +34,8 @@ public class TokenServiceImpl implements TokenService {
     public Token newTokenFromString(@Nonnull String tokenStr) {
         try {
             Algorithm algorithm =
-                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey("token-public.pem", "RSA"),
-                                 (RSAPrivateKey) this.keyService.getPrivateKey("token-private.pem", "RSA"));
+                Algorithm.RSA256((RSAPublicKey) this.keyService.getPublicKey(KEY_NAME, "RSA"),
+                                 (RSAPrivateKey) this.keyService.getPrivateKey(KEY_NAME, "RSA"));
             JWTVerifier verifier = JWT.require(algorithm).build();
 
             DecodedJWT jwt = verifier.verify(tokenStr);


### PR DESCRIPTION
`initVault.sh` should be executed before starting backend server in order to start Vault server and create RSA keys.